### PR TITLE
feat : 회원 탈퇴 시 관련 데이터 삭제 처리

### DIFF
--- a/src/main/java/com/retro/domain/member/application/MemberService.java
+++ b/src/main/java/com/retro/domain/member/application/MemberService.java
@@ -2,6 +2,7 @@ package com.retro.domain.member.application;
 
 import com.retro.domain.member.domain.MemberRepository;
 import com.retro.domain.member.domain.entity.Member;
+import com.retro.domain.member.domain.event.MemberEventPublisher;
 import com.retro.global.common.exception.BusinessException;
 import com.retro.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
   private final MemberRepository memberRepository;
+  private final MemberEventPublisher memberEventPublisher;
 
   public Member getMember(Long memberId) {
     return memberRepository.findById(memberId)
@@ -41,5 +43,12 @@ public class MemberService {
   public void updateNickname(Long memberId, String nickname) {
     Member member = getMember(memberId);
     member.updateNickname(nickname);
+  }
+
+  @Transactional
+  public void withdrawMember(Long memberId) {
+    Member member = getMember(memberId);
+    memberEventPublisher.publishMemberWithdrawnEvent(member);
+    memberRepository.delete(member);
   }
 }

--- a/src/main/java/com/retro/domain/member/domain/MemberRepository.java
+++ b/src/main/java/com/retro/domain/member/domain/MemberRepository.java
@@ -5,8 +5,15 @@ import com.retro.domain.member.domain.entity.Provider;
 import java.util.Optional;
 
 public interface MemberRepository {
-    Member save(Member member);
-    Optional<Member> findById(Long id);
-    boolean existsByProviderAndProviderId(Provider provider, String providerId);
-    Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+  Member save(Member member);
+
+  Optional<Member> findById(Long id);
+
+  boolean existsByProviderAndProviderId(Provider provider, String providerId);
+
+  Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+  void delete(Member member);
+
 }

--- a/src/main/java/com/retro/domain/member/domain/entity/Member.java
+++ b/src/main/java/com/retro/domain/member/domain/entity/Member.java
@@ -29,6 +29,8 @@ import lombok.NoArgsConstructor;
     })
 public class Member extends BaseEntity {
 
+  public static final Long DELETED_MEMBER_ID = -1L;
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/retro/domain/member/domain/event/MemberEventPublisher.java
+++ b/src/main/java/com/retro/domain/member/domain/event/MemberEventPublisher.java
@@ -1,0 +1,20 @@
+package com.retro.domain.member.domain.event;
+
+import com.retro.domain.member.domain.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberEventPublisher {
+
+  private final ApplicationEventPublisher applicationEventPublisher;
+
+  public void publishMemberWithdrawnEvent(Member member) {
+    MemberWithdrawnEvent memberWithdrawnEvent = MemberWithdrawnEvent.of(member.getId());
+    applicationEventPublisher.publishEvent(memberWithdrawnEvent);
+  }
+
+
+}

--- a/src/main/java/com/retro/domain/member/domain/event/MemberWithdrawnEvent.java
+++ b/src/main/java/com/retro/domain/member/domain/event/MemberWithdrawnEvent.java
@@ -1,0 +1,8 @@
+package com.retro.domain.member.domain.event;
+
+public record MemberWithdrawnEvent(Long memberId) {
+
+  public static MemberWithdrawnEvent of(Long memberId) {
+    return new MemberWithdrawnEvent(memberId);
+  }
+}

--- a/src/main/java/com/retro/domain/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/com/retro/domain/member/infrastructure/MemberRepositoryImpl.java
@@ -33,4 +33,9 @@ public class MemberRepositoryImpl implements MemberRepository {
   public Optional<Member> findByProviderAndProviderId(Provider provider, String providerId) {
     return memberJPARepository.findByProviderAndProviderId(provider, providerId);
   }
+
+  @Override
+  public void delete(Member member) {
+    memberJPARepository.delete(member);
+  }
 }

--- a/src/main/java/com/retro/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/retro/domain/member/presentation/MemberController.java
@@ -7,6 +7,7 @@ import com.retro.global.common.dto.ApiResponse;
 import com.retro.global.common.utils.SecurityUtil;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +35,12 @@ public class MemberController {
       @RequestBody @Valid MemberNicknameUpdateRequest request
   ) {
     memberService.updateNickname(securityUtil.getAuthenticatedUserId(), request.nickname());
+    return ApiResponse.success();
+  }
+
+  @DeleteMapping
+  public ApiResponse<Void> withdrawMember() {
+    memberService.withdrawMember(securityUtil.getAuthenticatedUserId());
     return ApiResponse.success();
   }
 }

--- a/src/main/java/com/retro/domain/retro/application/RetroFacade.java
+++ b/src/main/java/com/retro/domain/retro/application/RetroFacade.java
@@ -1,0 +1,15 @@
+package com.retro.domain.retro.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RetroFacade {
+
+  private final RetroService retroService;
+
+  public void updateRetrosForWithdrawnMember(Long memberId) {
+    retroService.updateRetrosForWithdrawnMember(memberId);
+  }
+}

--- a/src/main/java/com/retro/domain/retro/application/RetroService.java
+++ b/src/main/java/com/retro/domain/retro/application/RetroService.java
@@ -1,7 +1,6 @@
 package com.retro.domain.retro.application;
 
 import com.retro.domain.member.application.MemberFacade;
-import com.retro.domain.member.domain.MemberRepository;
 import com.retro.domain.member.domain.entity.Member;
 import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
@@ -28,7 +27,6 @@ import org.springframework.util.CollectionUtils;
 public class RetroService {
 
   private final RetroRepository retroRepository;
-  private final MemberRepository memberRepository;
   private final KeywordRepository keywordRepository;
   private final MemberFacade memberFacade;
 
@@ -118,5 +116,15 @@ public class RetroService {
 
   private boolean hasMoreRetros(int size, List<Retro> retros) {
     return retros.size() > size;
+  }
+
+  @Transactional
+  public void updateRetrosForWithdrawnMember(Long memberId) {
+    List<Retro> retros = retroRepository.findAllByMemberId(memberId);
+    updateDeletedMembersRetros(retros);
+  }
+
+  private void updateDeletedMembersRetros(List<Retro> retros) {
+    retros.forEach(retro -> retro.markAsWithdrawnMember(Member.DELETED_MEMBER_ID));
   }
 }

--- a/src/main/java/com/retro/domain/retro/domain/entity/Retro.java
+++ b/src/main/java/com/retro/domain/retro/domain/entity/Retro.java
@@ -104,4 +104,8 @@ public class Retro extends BaseEntity {
   public boolean isCreatedByViewer(Long creatorId, Long viewerId) {
     return creatorId.equals(viewerId);
   }
+
+  public void markAsWithdrawnMember(Long deletedMemberId) {
+    this.memberId = deletedMemberId;
+  }
 }

--- a/src/main/java/com/retro/domain/retro/domain/event/RetroEventConsumer.java
+++ b/src/main/java/com/retro/domain/retro/domain/event/RetroEventConsumer.java
@@ -1,0 +1,19 @@
+package com.retro.domain.retro.domain.event;
+
+import com.retro.domain.member.domain.event.MemberWithdrawnEvent;
+import com.retro.domain.retro.application.RetroFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RetroEventConsumer {
+
+  private final RetroFacade retroFacade;
+
+  @EventListener
+  public void consumeMemberWithdrawnEvent(MemberWithdrawnEvent memberWithdrawnEvent) {
+    retroFacade.updateRetrosForWithdrawnMember(memberWithdrawnEvent.memberId());
+  }
+}

--- a/src/main/java/com/retro/domain/retro/domain/repository/RetroRepository.java
+++ b/src/main/java/com/retro/domain/retro/domain/repository/RetroRepository.java
@@ -13,4 +13,7 @@ public interface RetroRepository {
   List<Retro> findByMemberIdWithCursor(Long memberId, Long cursorId, int size);
 
   void delete(Retro retro);
+
+  List<Retro> findAllByMemberId(Long memberId);
+
 }

--- a/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryImpl.java
+++ b/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryImpl.java
@@ -34,4 +34,9 @@ public class RetroRepositoryImpl implements RetroRepository {
   public void delete(Retro retro) {
     retroJPARepository.delete(retro);
   }
+
+  @Override
+  public List<Retro> findAllByMemberId(Long memberId) {
+    return retroJPARepository.findAllByMemberId(memberId);
+  }
 }

--- a/src/main/java/com/retro/domain/retro/infrastructure/jpa/RetroJPARepository.java
+++ b/src/main/java/com/retro/domain/retro/infrastructure/jpa/RetroJPARepository.java
@@ -1,8 +1,10 @@
 package com.retro.domain.retro.infrastructure.jpa;
 
 import com.retro.domain.retro.domain.entity.Retro;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RetroJPARepository extends JpaRepository<Retro, Long> {
 
+  List<Retro> findAllByMemberId(Long memberId);
 }

--- a/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
+++ b/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
@@ -54,6 +54,32 @@ class RetroServiceTest {
   @Mock
   private MemberFacade memberFacade;
 
+  @Test
+  @DisplayName("성공: 탈퇴한 회원의 회고 작성자 ID를 일괄 변경한다")
+  void updateRetrosForWithdrawnMember() {
+
+    // given
+    Long memberId = 1L;
+    Retro retro1 = Retro.of(memberId, "네이버1", "FE", LocalDate.now(), "2차", "#React", "K", "P",
+        "T",
+        "요약");
+    Retro retro2 = Retro.of(memberId, "네이버2", "FE", LocalDate.now(), "2차", "#React", "K", "P",
+        "T",
+        "요약");
+    Retro retro3 = Retro.of(memberId, "네이버3", "FE", LocalDate.now(), "2차", "#React", "K", "P",
+        "T",
+        "요약");
+    List<Retro> retros = List.of(retro1, retro2, retro3);
+
+    given(retroRepository.findAllByMemberId(memberId)).willReturn(retros);
+
+    // when
+    retroService.updateRetrosForWithdrawnMember(memberId);
+
+    // then
+    verify(retroRepository).findAllByMemberId(memberId);
+  }
+
   @Nested
   @DisplayName("회고 생성(createRetro) 테스트")
   class CreateRetro {


### PR DESCRIPTION
- 회원 탈퇴 시 관련 데이터 삭제 처리
- 탈퇴한 회원이 작성한 회고는, 가입된 회원들과 구분 가능하도록 회고의 memberID를 -1로 지정하도록 변경