### PR TITLE
fix : 토큰 유효성 검증 API 응답코드 수정

### DIFF
--- a/src/main/java/com/retro/domain/auth/application/AuthService.java
+++ b/src/main/java/com/retro/domain/auth/application/AuthService.java
@@ -142,8 +142,12 @@ public class AuthService {
   }
 
   public TokenVerificationResponse validateToken(String token) {
-    boolean isExpired = jwtProvider.validateToken(token);
-    return TokenVerificationResponse.of(isExpired);
+
+    boolean isValidToken = jwtProvider.validateToken(token);
+    if (!isValidToken) {
+      throw new BusinessException(ErrorCode.INVALID_TOKEN);
+    }
+    return TokenVerificationResponse.of(isValidToken);
   }
 
   /**

--- a/src/main/java/com/retro/domain/auth/application/dto/response/TokenVerificationResponse.java
+++ b/src/main/java/com/retro/domain/auth/application/dto/response/TokenVerificationResponse.java
@@ -9,23 +9,14 @@ public record TokenVerificationResponse(
 
   // boolean 값을 직접 받아서 내부에서 분기 처리 후 객체 생성
   public static TokenVerificationResponse of(boolean isValid) {
-    VerificationStatus status = VerificationStatus.from(isValid);
+    VerificationStatus status = VerificationStatus.VALID;
     return new TokenVerificationResponse(status.getMessage());
   }
 
   @Getter
   @RequiredArgsConstructor
   public enum VerificationStatus {
-    VALID("유효한 토큰입니다."),
-    INVALID("유효하지 않은 토큰입니다.");
-
+    VALID("유효한 토큰입니다.");
     private final String message;
-
-    public static VerificationStatus from(boolean isValid) {
-      if (isValid) {
-        return VALID;
-      }
-      return INVALID;
-    }
   }
 }

--- a/src/main/java/com/retro/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/retro/domain/auth/presentation/AuthController.java
@@ -7,6 +7,7 @@ import com.retro.domain.auth.application.dto.request.RefreshRequest;
 import com.retro.domain.auth.application.dto.request.TokenValidationRequest;
 import com.retro.domain.auth.application.dto.response.AppleAuthCodeDto;
 import com.retro.domain.auth.application.dto.response.TokenVerificationResponse;
+import com.retro.domain.auth.application.dto.response.TokenVerificationResponse.VerificationStatus;
 import com.retro.global.UserAgentHeader;
 import com.retro.global.common.dto.ApiResponse;
 import com.retro.global.common.dto.MemberDevice;
@@ -17,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -133,6 +135,12 @@ public class AuthController {
   public ApiResponse<TokenVerificationResponse> validateToken(
       @RequestBody @Validated TokenValidationRequest request
   ) {
+    TokenVerificationResponse response = authService.validateToken(
+        request.token());
+    if (Objects.equals(response.message(), VerificationStatus.VALID.getMessage())) {
+      return ApiResponse.success(authService.validateToken(request.token()));
+    }
+
     return ApiResponse.success(authService.validateToken(request.token()));
   }
 }

--- a/src/test/java/com/retro/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/retro/domain/auth/application/AuthServiceTest.java
@@ -22,10 +22,12 @@ import com.retro.domain.member.domain.entity.Provider;
 import com.retro.domain.member.domain.entity.Term;
 import com.retro.global.common.dto.MemberDevice;
 import com.retro.global.common.enums.DeviceType;
+import com.retro.global.common.exception.BusinessException;
 import com.retro.global.common.exception.ErrorCode;
 import com.retro.global.common.jwt.JwtProvider;
 import com.retro.global.common.jwt.JwtToken;
 import java.util.Optional;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -206,14 +208,14 @@ class AuthServiceTest {
 
   @Test
   void validateTokenReturnsFalseWhenJwtIsInvalid() {
+    // given
     when(jwtProvider.validateToken("invalid-token")).thenReturn(false);
 
-    TokenVerificationResponse tokenVerificationResponse = authService.validateToken(
-        "invalid-token");
+    // when & then
+    Assertions.assertThatThrownBy(() -> authService.validateToken(
+            "invalid-token")).isInstanceOf(BusinessException.class)
+        .hasMessageContaining("유효하지 않은 토큰입니다.");
 
-    assertThat(tokenVerificationResponse.message()).isEqualTo(
-        VerificationStatus.INVALID.getMessage());
-    verify(jwtProvider, times(1)).validateToken("invalid-token");
   }
 
 }


### PR DESCRIPTION
- 유효성 검증 결과 만료된 토큰일 경우 상태코드 200을 반환하는 대신 예외처리와 함께 상태코드 401을 반환하도록 변경하였음
- 토큰 유효성 검증 API의 반환타입으로 사용되는 TokenVerificationResponse 내부에 불필요한 상수 필드를 제거하였음
- 위 변경사항에 따른 단위테스트 수정