### PR TITLE
feat: 회고 수정 및 삭제 API 개발

### DIFF
--- a/src/main/java/com/retro/domain/retro/application/RetroService.java
+++ b/src/main/java/com/retro/domain/retro/application/RetroService.java
@@ -186,7 +186,9 @@ public class RetroService {
     );
 
     List<InterviewQuestion> newQuestions = request.toQuestionEntities();
-    retro.replaceQuestions(newQuestions);
+    if (newQuestions != null) {
+      retro.replaceQuestions(newQuestions);
+    }
   }
 
   @Transactional

--- a/src/main/java/com/retro/domain/retro/application/RetroService.java
+++ b/src/main/java/com/retro/domain/retro/application/RetroService.java
@@ -164,4 +164,9 @@ public class RetroService {
     }
     
   }
+
+  @Transactional
+  public void updateRetro(){
+
+  }
 }

--- a/src/main/java/com/retro/domain/retro/application/RetroService.java
+++ b/src/main/java/com/retro/domain/retro/application/RetroService.java
@@ -4,6 +4,7 @@ import com.retro.domain.member.application.MemberFacade;
 import com.retro.domain.member.domain.entity.Member;
 import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
+import com.retro.domain.retro.application.dto.request.RetroUpdateRequest;
 import com.retro.domain.retro.application.dto.response.KeywordResponse;
 import com.retro.domain.retro.application.dto.response.RetroDetailResponse;
 import com.retro.domain.retro.domain.entity.InterviewQuestion;
@@ -166,7 +167,41 @@ public class RetroService {
   }
 
   @Transactional
-  public void updateRetro(){
+  public void updateRetro(Long memberId, Long retroId, RetroUpdateRequest request) {
+    Retro retro = retroRepository.findById(retroId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.RETRO_NOT_FOUND));
 
+    validateOwner(retro, memberId);
+
+    retro.update(
+        request.companyName(),
+        request.position(),
+        request.interviewDate(),
+        request.interviewRound(),
+        request.interviewTags(),
+        request.keepText(),
+        request.problemText(),
+        request.tryText(),
+        request.summary()
+    );
+
+    List<InterviewQuestion> newQuestions = request.toQuestionEntities();
+    retro.replaceQuestions(newQuestions);
+  }
+
+  @Transactional
+  public void deleteRetro(Long memberId, Long retroId) {
+    Retro retro = retroRepository.findById(retroId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.RETRO_NOT_FOUND));
+
+    validateOwner(retro, memberId);
+
+    retroRepository.delete(retro);
+  }
+
+  private void validateOwner(Retro retro, Long memberId) {
+    if (!retro.isOwnedBy(memberId)) {
+      throw new BusinessException(ErrorCode.RETRO_NOT_OWNER);
+    }
   }
 }

--- a/src/main/java/com/retro/domain/retro/application/dto/request/RetroUpdateRequest.java
+++ b/src/main/java/com/retro/domain/retro/application/dto/request/RetroUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.retro.domain.retro.application.dto.request;
+
+public record RetroUpdateRequest() {
+}

--- a/src/main/java/com/retro/domain/retro/application/dto/request/RetroUpdateRequest.java
+++ b/src/main/java/com/retro/domain/retro/application/dto/request/RetroUpdateRequest.java
@@ -32,10 +32,11 @@ public record RetroUpdateRequest(
 
   public List<InterviewQuestion> toQuestionEntities() {
     if (questions == null) {
-      return List.of();
+      return null;
     }
     return questions.stream()
         .map(QuestionRequest::toEntity)
         .toList();
   }
+
 }

--- a/src/main/java/com/retro/domain/retro/application/dto/request/RetroUpdateRequest.java
+++ b/src/main/java/com/retro/domain/retro/application/dto/request/RetroUpdateRequest.java
@@ -1,4 +1,41 @@
 package com.retro.domain.retro.application.dto.request;
 
-public record RetroUpdateRequest() {
+import com.retro.domain.retro.domain.entity.InterviewQuestion;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+
+public record RetroUpdateRequest(
+    @NotBlank(message = "회사명은 필수입니다.")
+    String companyName,
+    @NotBlank(message = "지원 직무는 필수입니다.")
+    String position,
+    @NotNull(message = "면접 일자는 필수입니다.")
+    LocalDate interviewDate,
+    @NotBlank(message = "면접 차수는 필수입니다.")
+    String interviewRound,
+    @Nullable
+    String interviewTags,
+    @Nullable
+    String keepText,
+    @Nullable
+    String problemText,
+    @Nullable
+    String tryText,
+    @Nullable
+    String summary,
+    @Nullable
+    List<QuestionRequest> questions
+) {
+
+  public List<InterviewQuestion> toQuestionEntities() {
+    if (questions == null) {
+      return List.of();
+    }
+    return questions.stream()
+        .map(QuestionRequest::toEntity)
+        .toList();
+  }
 }

--- a/src/main/java/com/retro/domain/retro/domain/entity/InterviewQuestion.java
+++ b/src/main/java/com/retro/domain/retro/domain/entity/InterviewQuestion.java
@@ -73,4 +73,14 @@ public class InterviewQuestion {
   protected void assignToRetro(Retro retro) {
     this.retro = retro;
   }
+
+  public void update(int questionOrder, String questionType, String questionText,
+      String answerText, String interviewerReaction, int satisfactionScore) {
+    this.questionOrder = questionOrder;
+    this.questionType = questionType;
+    this.questionText = questionText;
+    this.answerText = answerText;
+    this.interviewerReaction = interviewerReaction;
+    this.satisfactionScore = satisfactionScore;
+  }
 }

--- a/src/main/java/com/retro/domain/retro/domain/entity/Retro.java
+++ b/src/main/java/com/retro/domain/retro/domain/entity/Retro.java
@@ -144,4 +144,29 @@ public class Retro extends BaseEntity {
     this.reports.add(report);
     report.addRetro(this);
   }
+
+  public boolean isOwnedBy(Long memberId) {
+    return this.memberId.equals(memberId);
+  }
+
+  public void update(String companyName, String position, LocalDate interviewDate,
+      String interviewRound, String interviewTags, String keepText,
+      String problemText, String tryText, String summary) {
+    this.companyName = companyName;
+    this.position = position;
+    this.interviewDate = interviewDate;
+    this.interviewRound = interviewRound;
+    this.interviewTags = interviewTags;
+    this.keepText = keepText;
+    this.problemText = problemText;
+    this.tryText = tryText;
+    this.summary = summary;
+  }
+
+  public void replaceQuestions(List<InterviewQuestion> newQuestions) {
+    this.questions.clear();
+    if (newQuestions != null) {
+      newQuestions.forEach(this::addQuestion);
+    }
+  }
 }

--- a/src/main/java/com/retro/domain/retro/presentation/RetroController.java
+++ b/src/main/java/com/retro/domain/retro/presentation/RetroController.java
@@ -114,7 +114,7 @@ public class RetroController {
 
   @Operation(
           summary = "회고 수정",
-          description = "회고에 대한 내용을 업데이트 합니다."
+          description = "본인이 작성한 회고의 내용을 수정합니다."
   )
   @io.swagger.v3.oas.annotations.responses.ApiResponse(
           responseCode = "200",
@@ -124,8 +124,28 @@ public class RetroController {
           )
   )
   @PutMapping("/{retroId}")
-  public ApiResponse<Void> updateRetro(@PathVariable Long retroId, @RequestBody RetroUpdateRequest request) {
+  public ApiResponse<Void> updateRetro(@PathVariable Long retroId,
+      @RequestBody @Valid RetroUpdateRequest request) {
+    Long memberId = securityUtil.getAuthenticatedUserId();
+    retroService.updateRetro(memberId, retroId, request);
+    return ApiResponse.success();
+  }
 
+  @Operation(
+          summary = "회고 삭제",
+          description = "본인이 작성한 회고를 삭제합니다."
+  )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+          responseCode = "200",
+          description = "성공",
+          content = @io.swagger.v3.oas.annotations.media.Content(
+                  mediaType = MediaType.APPLICATION_JSON_VALUE
+          )
+  )
+  @DeleteMapping("/{retroId}")
+  public ApiResponse<Void> deleteRetro(@PathVariable Long retroId) {
+    Long memberId = securityUtil.getAuthenticatedUserId();
+    retroService.deleteRetro(memberId, retroId);
     return ApiResponse.success();
   }
 }

--- a/src/main/java/com/retro/domain/retro/presentation/RetroController.java
+++ b/src/main/java/com/retro/domain/retro/presentation/RetroController.java
@@ -3,6 +3,7 @@ package com.retro.domain.retro.presentation;
 import com.retro.domain.retro.application.RetroService;
 import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
+import com.retro.domain.retro.application.dto.request.RetroUpdateRequest;
 import com.retro.domain.retro.application.dto.response.KeywordResponse;
 import com.retro.domain.retro.application.dto.response.RetroCreateResponse;
 import com.retro.domain.retro.application.dto.response.RetroDetailResponse;
@@ -15,13 +16,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Retro API", description = "회고 작성 및 조회 API")
 @RestController
@@ -97,7 +92,6 @@ public class RetroController {
           mediaType = MediaType.APPLICATION_JSON_VALUE
       )
   )
-
   @GetMapping("/my-retros")
   public ApiResponse<RetroCursorPageResponse> getMyRetros(
       @RequestParam(required = false) Long cursorId,
@@ -115,6 +109,23 @@ public class RetroController {
   public ApiResponse<Void> reportRetro(@PathVariable Long retroId) {
     Long reporterId = securityUtil.getAuthenticatedUserId();
     retroService.reportRetro(reporterId, retroId);
+    return ApiResponse.success();
+  }
+
+  @Operation(
+          summary = "회고 수정",
+          description = "회고에 대한 내용을 업데이트 합니다."
+  )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+          responseCode = "200",
+          description = "성공",
+          content = @io.swagger.v3.oas.annotations.media.Content(
+                  mediaType = MediaType.APPLICATION_JSON_VALUE
+          )
+  )
+  @PutMapping("/{retroId}")
+  public ApiResponse<Void> updateRetro(@PathVariable Long retroId, @RequestBody RetroUpdateRequest request) {
+
     return ApiResponse.success();
   }
 }

--- a/src/main/java/com/retro/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/retro/global/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
   RETRO_READ_POINT_EXCEEDED(403, "RETRO-2002", "회고 열람 가능 횟수를 초과했습니다."),
   RETRO_BLINDED(403, "RETRO-2003", "블라인드 처리된 게시물입니다."),
   RETRO_ALREADY_REPORTED(400, "RETRO-2004", "이미 신고한 게시물입니다."),
+  RETRO_NOT_OWNER(403, "RETRO-2005", "본인이 작성한 회고만 수정/삭제할 수 있습니다."),
   
   // ===== 3000번대: 질문 관련 =====
   QUESTION_NOT_FOUND(404, "QUESTION-3001", "존재하지 않는 질문입니다."),

--- a/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
+++ b/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
@@ -517,6 +517,34 @@ class RetroServiceTest {
     }
 
     @Test
+    @DisplayName("성공: 질문 목록을 수정하지 않으려고 null로 보내면 기존 질문이 유지된다")
+    void success_updateRetroKeepQuestions_whenQuestionsNull() {
+      // given
+      Long memberId = 1L;
+      Long retroId = 10L;
+
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      ReflectionTestUtils.setField(retro, "retroId", retroId);
+
+      InterviewQuestion oldQuestion = InterviewQuestion.of(1, "기술", "기존질문", "기존답변", "좋음", 3);
+      retro.addQuestion(oldQuestion);
+
+      RetroUpdateRequest request = new RetroUpdateRequest(
+          "카카오", "BE", LocalDate.of(2026, 3, 20), "2차", "#Java",
+          "Keep수정", "Problem수정", "Try수정", "요약수정", null
+      );
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
+
+      // when
+      retroService.updateRetro(memberId, retroId, request);
+
+      // then
+      assertThat(retro.getQuestions()).hasSize(1);
+      assertThat(retro.getQuestions().get(0).getQuestionText()).isEqualTo("기존질문");
+    }
+
+    @Test
     @DisplayName("성공: 질문이 포함된 수정 요청 시 기존 질문이 교체된다")
     void success_updateRetroWithQuestions() {
       // given

--- a/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
+++ b/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
@@ -16,6 +16,7 @@ import com.retro.domain.member.domain.entity.Member;
 import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.QuestionRequest;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
+import com.retro.domain.retro.application.dto.request.RetroUpdateRequest;
 import com.retro.domain.retro.application.dto.response.KeywordResponse;
 import com.retro.domain.retro.application.dto.response.RetroDetailResponse;
 import com.retro.domain.retro.domain.entity.InterviewQuestion;
@@ -481,5 +482,179 @@ class RetroServiceTest {
     }
   }
 
+  @Nested
+  @DisplayName("회고 수정(updateRetro)")
+  class UpdateRetro {
+
+    @Test
+    @DisplayName("성공: 본인 회고를 수정하면 필드가 업데이트된다")
+    void success_updateRetro() {
+      // given
+      Long memberId = 1L;
+      Long retroId = 10L;
+
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      ReflectionTestUtils.setField(retro, "retroId", retroId);
+
+      RetroUpdateRequest request = new RetroUpdateRequest(
+          "카카오", "BE", LocalDate.of(2026, 3, 20), "2차", "#Java",
+          "Keep수정", "Problem수정", "Try수정", "요약수정", null
+      );
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
+
+      // when
+      retroService.updateRetro(memberId, retroId, request);
+
+      // then
+      assertThat(retro.getCompanyName()).isEqualTo("카카오");
+      assertThat(retro.getPosition()).isEqualTo("BE");
+      assertThat(retro.getInterviewRound()).isEqualTo("2차");
+      assertThat(retro.getKeepText()).isEqualTo("Keep수정");
+      assertThat(retro.getProblemText()).isEqualTo("Problem수정");
+      assertThat(retro.getTryText()).isEqualTo("Try수정");
+      assertThat(retro.getSummary()).isEqualTo("요약수정");
+    }
+
+    @Test
+    @DisplayName("성공: 질문이 포함된 수정 요청 시 기존 질문이 교체된다")
+    void success_updateRetroWithQuestions() {
+      // given
+      Long memberId = 1L;
+      Long retroId = 10L;
+
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      ReflectionTestUtils.setField(retro, "retroId", retroId);
+
+      InterviewQuestion oldQuestion = InterviewQuestion.of(1, "기술", "기존질문", "기존답변", "좋음", 3);
+      retro.addQuestion(oldQuestion);
+
+      List<QuestionRequest> newQuestions = List.of(
+          QuestionRequest.of(1, "기술", "새질문1", "새답변1", "좋음", 5),
+          QuestionRequest.of(2, "인성", "새질문2", "새답변2", "보통", 3)
+      );
+
+      RetroUpdateRequest request = new RetroUpdateRequest(
+          "카카오", "BE", LocalDate.of(2026, 3, 20), "2차", "#Java",
+          "Keep수정", "Problem수정", "Try수정", "요약수정", newQuestions
+      );
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
+
+      // when
+      retroService.updateRetro(memberId, retroId, request);
+
+      // then
+      assertThat(retro.getQuestions()).hasSize(2);
+      assertThat(retro.getQuestions().get(0).getQuestionText()).isEqualTo("새질문1");
+      assertThat(retro.getQuestions().get(1).getQuestionText()).isEqualTo("새질문2");
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 회고를 수정하면 RETRO_NOT_FOUND 예외를 던진다")
+    void fail_retroNotFound() {
+      // given
+      Long memberId = 1L;
+      Long retroId = 999L;
+
+      RetroUpdateRequest request = new RetroUpdateRequest(
+          "카카오", "BE", LocalDate.of(2026, 3, 20), "2차", "#Java",
+          "K", "P", "T", "요약", null
+      );
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> retroService.updateRetro(memberId, retroId, request))
+          .isInstanceOf(BusinessException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RETRO_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패: 본인 회고가 아닌 경우 RETRO_NOT_OWNER 예외를 던진다")
+    void fail_notOwner() {
+      // given
+      Long memberId = 1L;
+      Long otherMemberId = 2L;
+      Long retroId = 10L;
+
+      Retro retro = Retro.of(otherMemberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      ReflectionTestUtils.setField(retro, "retroId", retroId);
+
+      RetroUpdateRequest request = new RetroUpdateRequest(
+          "카카오", "BE", LocalDate.of(2026, 3, 20), "2차", "#Java",
+          "K", "P", "T", "요약", null
+      );
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
+
+      // when & then
+      assertThatThrownBy(() -> retroService.updateRetro(memberId, retroId, request))
+          .isInstanceOf(BusinessException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RETRO_NOT_OWNER);
+    }
+  }
+
+  @Nested
+  @DisplayName("회고 삭제(deleteRetro)")
+  class DeleteRetro {
+
+    @Test
+    @DisplayName("성공: 본인 회고를 삭제한다")
+    void success_deleteRetro() {
+      // given
+      Long memberId = 1L;
+      Long retroId = 10L;
+
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      ReflectionTestUtils.setField(retro, "retroId", retroId);
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
+
+      // when
+      retroService.deleteRetro(memberId, retroId);
+
+      // then
+      verify(retroRepository).delete(retro);
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 회고를 삭제하면 RETRO_NOT_FOUND 예외를 던진다")
+    void fail_retroNotFound() {
+      // given
+      Long memberId = 1L;
+      Long retroId = 999L;
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> retroService.deleteRetro(memberId, retroId))
+          .isInstanceOf(BusinessException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RETRO_NOT_FOUND);
+
+      verify(retroRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("실패: 본인 회고가 아닌 경우 RETRO_NOT_OWNER 예외를 던진다")
+    void fail_notOwner() {
+      // given
+      Long memberId = 1L;
+      Long otherMemberId = 2L;
+      Long retroId = 10L;
+
+      Retro retro = Retro.of(otherMemberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      ReflectionTestUtils.setField(retro, "retroId", retroId);
+
+      given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
+
+      // when & then
+      assertThatThrownBy(() -> retroService.deleteRetro(memberId, retroId))
+          .isInstanceOf(BusinessException.class)
+          .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RETRO_NOT_OWNER);
+
+      verify(retroRepository, never()).delete(any());
+    }
+  }
 
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                       
  - 본인이 작성한 회고를 수정(`PUT /retros/{retroId}`)하고 삭제(`DELETE /retros/{retroId}`)할 수 있는 API 추가                                                                                                                                                                                                     
  - 본인 소유 검증 로직(`RETRO_NOT_OWNER`) 및 면접 질문 교체 기능 포함                                                                                                                                                                                                                                             
  - 수정/삭제 성공·실패 케이스에 대한 단위 테스트 추가                                                                                                                                                                                                                                                             

  ## Changes
  - `RetroController` — 회고 수정(PUT), 삭제(DELETE) 엔드포인트 추가
  - `RetroService` — `updateRetro`, `deleteRetro`, `validateOwner` 메서드 추가
  - `RetroUpdateRequest` — 수정 요청 DTO 및 질문 변환 로직
  - `Retro` 엔티티 — `update`, `replaceQuestions`, `isOwnedBy` 메서드 추가
  - `ErrorCode` — `RETRO_NOT_OWNER(403)` 추가
  - `RetroServiceTest` — 수정/삭제 성공·실패 테스트 7건 추가

  ## Test plan
  - [x] 회고 수정 성공 (필드 업데이트 검증)
  - [x] 질문 포함 수정 시 기존 질문 교체 검증
  - [x] 존재하지 않는 회고 수정/삭제 시 RETRO_NOT_FOUND 예외
  - [x] 타인의 회고 수정/삭제 시 RETRO_NOT_OWNER 예외
  - [x] 회고 삭제 성공 (repository.delete 호출 검증)
  
  ---
  
  ## 3.31 추가
  ### 버그 수정
- 질문 목록이 null로 전달될 경우, 변경 사항이 없어도 질문 목록을 초기화 하는 문제를 수정하여 변경 사항이 존재시 전체 변경하는 방식으로 수정

