### PR TITLE
feat : 커뮤니티 피드 조회 기능 구현

### DIFF
--- a/src/main/java/com/retro/domain/retro/application/RetroService.java
+++ b/src/main/java/com/retro/domain/retro/application/RetroService.java
@@ -5,6 +5,8 @@ import com.retro.domain.member.domain.entity.Member;
 import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
 import com.retro.domain.retro.application.dto.request.RetroUpdateRequest;
+import com.retro.domain.retro.application.dto.response.CommunityRetroCardResponse;
+import com.retro.domain.retro.application.dto.response.CommunityRetroFeedCursorPageResponse;
 import com.retro.domain.retro.application.dto.response.KeywordResponse;
 import com.retro.domain.retro.application.dto.response.RetroDetailResponse;
 import com.retro.domain.retro.domain.entity.InterviewQuestion;
@@ -163,7 +165,7 @@ public class RetroService {
     if (isBlinded) {
       retroEventPublisher.publishRetroBlindedEvent(RetroBlindedEvent.of(retro));
     }
-    
+
   }
 
   @Transactional
@@ -205,5 +207,21 @@ public class RetroService {
     if (!retro.isOwnedBy(memberId)) {
       throw new BusinessException(ErrorCode.RETRO_NOT_OWNER);
     }
+  }
+
+  public CommunityRetroFeedCursorPageResponse getCommunityFeed(Long cursorId, int size) {
+    final int pageSizePlusOne = size + 1;
+    List<Retro> retros = retroRepository.findPublicRetrosWithCursor(cursorId, pageSizePlusOne);
+    boolean hasNext = hasMoreRetros(size, retros);
+
+    if (hasNext) {
+      retros = sliceRetros(size, retros);
+    }
+
+    List<CommunityRetroCardResponse> responses = retros.stream()
+        .map(CommunityRetroCardResponse::from)
+        .toList();
+    Long nextCursor = getNextCursor(hasNext, retros);
+    return CommunityRetroFeedCursorPageResponse.of(responses, nextCursor, hasNext);
   }
 }

--- a/src/main/java/com/retro/domain/retro/application/dto/response/CommunityRetroCardResponse.java
+++ b/src/main/java/com/retro/domain/retro/application/dto/response/CommunityRetroCardResponse.java
@@ -1,0 +1,25 @@
+package com.retro.domain.retro.application.dto.response;
+
+import com.retro.domain.retro.domain.entity.Retro;
+import java.time.LocalDate;
+
+public record CommunityRetroCardResponse(
+    Long retroId,
+    String company,
+    String position,
+    LocalDate interviewDate,
+    String tags,
+    String summary
+) {
+
+  public static CommunityRetroCardResponse from(Retro retro) {
+    return new CommunityRetroCardResponse(
+        retro.getRetroId(),
+        retro.getCompanyName(),
+        retro.getPosition(),
+        retro.getInterviewDate(),
+        retro.getInterviewTags(),
+        retro.getSummary()
+    );
+  }
+}

--- a/src/main/java/com/retro/domain/retro/application/dto/response/CommunityRetroFeedCursorPageResponse.java
+++ b/src/main/java/com/retro/domain/retro/application/dto/response/CommunityRetroFeedCursorPageResponse.java
@@ -1,0 +1,18 @@
+package com.retro.domain.retro.application.dto.response;
+
+import java.util.List;
+
+public record CommunityRetroFeedCursorPageResponse(
+    List<CommunityRetroCardResponse> retros,
+    Long nextCursor,
+    boolean hasNext
+) {
+
+  public static CommunityRetroFeedCursorPageResponse of(
+      List<CommunityRetroCardResponse> retros,
+      Long nextCursor,
+      boolean hasNext
+  ) {
+    return new CommunityRetroFeedCursorPageResponse(retros, nextCursor, hasNext);
+  }
+}

--- a/src/main/java/com/retro/domain/retro/domain/repository/RetroRepository.java
+++ b/src/main/java/com/retro/domain/retro/domain/repository/RetroRepository.java
@@ -13,6 +13,8 @@ public interface RetroRepository {
 
   List<Retro> findByMemberIdWithCursor(Long memberId, Long cursorId, int size);
 
+  List<Retro> findPublicRetrosWithCursor(Long cursorId, int size);
+
   void delete(Retro retro);
 
   List<Retro> findAllByMemberId(Long memberId);

--- a/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryCustom.java
+++ b/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryCustom.java
@@ -11,4 +11,6 @@ public interface RetroRepositoryCustom {
 
   Optional<RetroReport> existsReportByRetroAndReporter(Long retroId, Long reporterMemberId);
 
+  List<Retro> findPublicRetrosWithCursor(Long cursorId, int size);
+
 }

--- a/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryCustomImpl.java
+++ b/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryCustomImpl.java
@@ -1,12 +1,15 @@
 package com.retro.domain.retro.infrastructure;
 
+import static com.retro.domain.member.domain.entity.QMember.member;
 import static com.retro.domain.retro.domain.entity.QRetro.retro;
 import static com.retro.domain.retro.domain.entity.QRetroReport.retroReport;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.retro.domain.retro.domain.entity.Retro;
 import com.retro.domain.retro.domain.entity.RetroReport;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -45,5 +48,33 @@ public class RetroRepositoryCustomImpl implements RetroRepositoryCustom {
         .fetchOne();
 
     return Optional.ofNullable(report);
+  }
+
+  @Override
+  public List<Retro> findPublicRetrosWithCursor(Long cursorId, int size) {
+    return jpaQueryFactory
+        .selectFrom(retro)
+        .join(member).on(retro.memberId.eq(member.id))
+        .where(buildPublicFeedPredicate(cursorId))
+        .orderBy(retro.retroId.desc())
+        .limit(size)
+        .fetch();
+  }
+
+  private BooleanBuilder buildPublicFeedPredicate(Long cursorId) {
+    BooleanBuilder predicate = new BooleanBuilder();
+    predicate.and(member.isPublic.isTrue());
+    predicate.and(retro.blinded.isFalse());
+
+    return appendCursorCondition(predicate, cursorId);
+  }
+
+  private BooleanBuilder appendCursorCondition(BooleanBuilder predicate, Long cursorId) {
+    if (Objects.isNull(cursorId)) {
+      return predicate;
+    }
+
+    predicate.and(retro.retroId.lt(cursorId));
+    return predicate;
   }
 }

--- a/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryImpl.java
+++ b/src/main/java/com/retro/domain/retro/infrastructure/RetroRepositoryImpl.java
@@ -32,6 +32,11 @@ public class RetroRepositoryImpl implements RetroRepository {
   }
 
   @Override
+  public List<Retro> findPublicRetrosWithCursor(Long cursorId, int size) {
+    return retroRepositoryCustom.findPublicRetrosWithCursor(cursorId, size);
+  }
+
+  @Override
   public void delete(Retro retro) {
     retroJPARepository.delete(retro);
   }

--- a/src/main/java/com/retro/domain/retro/presentation/RetroController.java
+++ b/src/main/java/com/retro/domain/retro/presentation/RetroController.java
@@ -4,6 +4,7 @@ import com.retro.domain.retro.application.RetroService;
 import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
 import com.retro.domain.retro.application.dto.request.RetroUpdateRequest;
+import com.retro.domain.retro.application.dto.response.CommunityRetroFeedCursorPageResponse;
 import com.retro.domain.retro.application.dto.response.KeywordResponse;
 import com.retro.domain.retro.application.dto.response.RetroCreateResponse;
 import com.retro.domain.retro.application.dto.response.RetroDetailResponse;
@@ -16,7 +17,15 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Retro API", description = "회고 작성 및 조회 API")
 @RestController
@@ -113,15 +122,15 @@ public class RetroController {
   }
 
   @Operation(
-          summary = "회고 수정",
-          description = "본인이 작성한 회고의 내용을 수정합니다."
+      summary = "회고 수정",
+      description = "본인이 작성한 회고의 내용을 수정합니다."
   )
   @io.swagger.v3.oas.annotations.responses.ApiResponse(
-          responseCode = "200",
-          description = "성공",
-          content = @io.swagger.v3.oas.annotations.media.Content(
-                  mediaType = MediaType.APPLICATION_JSON_VALUE
-          )
+      responseCode = "200",
+      description = "성공",
+      content = @io.swagger.v3.oas.annotations.media.Content(
+          mediaType = MediaType.APPLICATION_JSON_VALUE
+      )
   )
   @PutMapping("/{retroId}")
   public ApiResponse<Void> updateRetro(@PathVariable Long retroId,
@@ -132,21 +141,33 @@ public class RetroController {
   }
 
   @Operation(
-          summary = "회고 삭제",
-          description = "본인이 작성한 회고를 삭제합니다."
+      summary = "회고 삭제",
+      description = "본인이 작성한 회고를 삭제합니다."
   )
   @io.swagger.v3.oas.annotations.responses.ApiResponse(
-          responseCode = "200",
-          description = "성공",
-          content = @io.swagger.v3.oas.annotations.media.Content(
-                  mediaType = MediaType.APPLICATION_JSON_VALUE
-          )
+      responseCode = "200",
+      description = "성공",
+      content = @io.swagger.v3.oas.annotations.media.Content(
+          mediaType = MediaType.APPLICATION_JSON_VALUE
+      )
   )
   @DeleteMapping("/{retroId}")
   public ApiResponse<Void> deleteRetro(@PathVariable Long retroId) {
     Long memberId = securityUtil.getAuthenticatedUserId();
     retroService.deleteRetro(memberId, retroId);
     return ApiResponse.success();
+  }
+
+  @Operation(
+      summary = "커뮤니티 피드 조회",
+      description = "공개 설정된 사용자의 익명 회고 카드 목록을 커서 기반으로 조회합니다."
+  )
+  @GetMapping("/community-feed")
+  public ApiResponse<CommunityRetroFeedCursorPageResponse> getCommunityFeed(
+      @RequestParam(required = false) Long cursorId,
+      @RequestParam(defaultValue = "20") int size) {
+    CommunityRetroFeedCursorPageResponse response = retroService.getCommunityFeed(cursorId, size);
+    return ApiResponse.success(response);
   }
 }
 

--- a/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
+++ b/src/test/java/com/retro/domain/retro/application/RetroServiceTest.java
@@ -17,6 +17,7 @@ import com.retro.domain.retro.application.dto.RetroCursorPageResponse;
 import com.retro.domain.retro.application.dto.request.QuestionRequest;
 import com.retro.domain.retro.application.dto.request.RetroCreateRequest;
 import com.retro.domain.retro.application.dto.request.RetroUpdateRequest;
+import com.retro.domain.retro.application.dto.response.CommunityRetroFeedCursorPageResponse;
 import com.retro.domain.retro.application.dto.response.KeywordResponse;
 import com.retro.domain.retro.application.dto.response.RetroDetailResponse;
 import com.retro.domain.retro.domain.entity.InterviewQuestion;
@@ -493,7 +494,8 @@ class RetroServiceTest {
       Long memberId = 1L;
       Long retroId = 10L;
 
-      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T",
+          "요약");
       ReflectionTestUtils.setField(retro, "retroId", retroId);
 
       RetroUpdateRequest request = new RetroUpdateRequest(
@@ -523,7 +525,8 @@ class RetroServiceTest {
       Long memberId = 1L;
       Long retroId = 10L;
 
-      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T",
+          "요약");
       ReflectionTestUtils.setField(retro, "retroId", retroId);
 
       InterviewQuestion oldQuestion = InterviewQuestion.of(1, "기술", "기존질문", "기존답변", "좋음", 3);
@@ -551,7 +554,8 @@ class RetroServiceTest {
       Long memberId = 1L;
       Long retroId = 10L;
 
-      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T",
+          "요약");
       ReflectionTestUtils.setField(retro, "retroId", retroId);
 
       InterviewQuestion oldQuestion = InterviewQuestion.of(1, "기술", "기존질문", "기존답변", "좋음", 3);
@@ -606,7 +610,8 @@ class RetroServiceTest {
       Long otherMemberId = 2L;
       Long retroId = 10L;
 
-      Retro retro = Retro.of(otherMemberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      Retro retro = Retro.of(otherMemberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P",
+          "T", "요약");
       ReflectionTestUtils.setField(retro, "retroId", retroId);
 
       RetroUpdateRequest request = new RetroUpdateRequest(
@@ -634,7 +639,8 @@ class RetroServiceTest {
       Long memberId = 1L;
       Long retroId = 10L;
 
-      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      Retro retro = Retro.of(memberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T",
+          "요약");
       ReflectionTestUtils.setField(retro, "retroId", retroId);
 
       given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
@@ -671,7 +677,8 @@ class RetroServiceTest {
       Long otherMemberId = 2L;
       Long retroId = 10L;
 
-      Retro retro = Retro.of(otherMemberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P", "T", "요약");
+      Retro retro = Retro.of(otherMemberId, "네이버", "FE", LocalDate.now(), "1차", "#React", "K", "P",
+          "T", "요약");
       ReflectionTestUtils.setField(retro, "retroId", retroId);
 
       given(retroRepository.findById(retroId)).willReturn(Optional.of(retro));
@@ -684,5 +691,64 @@ class RetroServiceTest {
       verify(retroRepository, never()).delete(any());
     }
   }
+
+  @Nested
+  @DisplayName("커뮤니티 피드 조회(getCommunityFeed)")
+  class GetCommunityFeed {
+
+    private static final int REQUEST_SIZE = 2;
+    private static final int PAGE_SIZE_PLUS_ONE = 3;
+
+    @Test
+    @DisplayName("성공: 익명 커뮤니티 카드 목록을 커서 기반으로 반환한다")
+    void success_getCommunityFeed() {
+      // given
+      Retro newest = Retro.of(10L, "네이버", "백엔드", LocalDate.now(), "2차", "#Spring", "K", "P", "T",
+          "요약1");
+      Retro oldest = Retro.of(11L, "카카오", "프론트엔드", LocalDate.now(), "1차", "#React", "K", "P", "T",
+          "요약2");
+      ReflectionTestUtils.setField(newest, "retroId", 101L);
+      ReflectionTestUtils.setField(oldest, "retroId", 99L);
+
+      given(retroRepository.findPublicRetrosWithCursor(null, PAGE_SIZE_PLUS_ONE))
+          .willReturn(List.of(newest, oldest));
+
+      // when
+      CommunityRetroFeedCursorPageResponse response = retroService.getCommunityFeed(null,
+          REQUEST_SIZE);
+
+      // then
+      assertThat(response.retros()).hasSize(2);
+      assertThat(response.retros().get(0).company()).isEqualTo("네이버");
+      assertThat(response.retros().get(0).position()).isEqualTo("백엔드");
+      assertThat(response.nextCursor()).isNull();
+      assertThat(response.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("성공: 페이지 사이즈보다 많으면 hasNext=true와 nextCursor를 반환한다")
+    void success_getCommunityFeed_withPaging() {
+      // given
+      Retro retro1 = Retro.of(10L, "A", "BE", LocalDate.now(), "1차", "#A", "K", "P", "T", "S1");
+      Retro retro2 = Retro.of(11L, "B", "FE", LocalDate.now(), "1차", "#B", "K", "P", "T", "S2");
+      Retro retro3 = Retro.of(12L, "C", "DE", LocalDate.now(), "1차", "#C", "K", "P", "T", "S3");
+      ReflectionTestUtils.setField(retro1, "retroId", 103L);
+      ReflectionTestUtils.setField(retro2, "retroId", 102L);
+      ReflectionTestUtils.setField(retro3, "retroId", 101L);
+
+      given(retroRepository.findPublicRetrosWithCursor(null, PAGE_SIZE_PLUS_ONE))
+          .willReturn(List.of(retro1, retro2, retro3));
+
+      // when
+      CommunityRetroFeedCursorPageResponse response = retroService.getCommunityFeed(null,
+          REQUEST_SIZE);
+
+      // then
+      assertThat(response.retros()).hasSize(2);
+      assertThat(response.hasNext()).isTrue();
+      assertThat(response.nextCursor()).isEqualTo(102L);
+    }
+  }
+
 
 }

--- a/src/test/java/com/retro/domain/retro/domain/repository/RetroRepositoryTest.java
+++ b/src/test/java/com/retro/domain/retro/domain/repository/RetroRepositoryTest.java
@@ -15,6 +15,7 @@ import com.retro.domain.retro.infrastructure.RetroRepositoryImpl;
 import com.retro.global.config.QuerydslConfig;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,46 @@ class RetroRepositoryTest {
   private MemberRepository memberRepository;
   @Autowired
   private EntityManager em; // Cascade를 확실히 검증하기 위해 필요
+
+
+  @Test
+  @DisplayName("커뮤니티 피드 조회: 공개 회원의 블라인드되지 않은 회고만 조회된다.")
+  void findPublicRetrosWithCursor_filtersByMemberPublicAndBlinded() {
+    // given
+    int querySize = 10;
+    Member publicMember = createAndSaveMember();
+    publicMember.openOwnPublication();
+
+    Member privateMember = createAndSaveMember();
+
+    Retro publicRetro = Retro.of(publicMember.getId(), "네이버", "BE", LocalDate.now(), "1차", "#Java",
+        "K", "P",
+        "T", "공개");
+    Retro privateRetro = Retro.of(privateMember.getId(), "카카오", "FE", LocalDate.now(), "1차",
+        "#React", "K", "P",
+        "T", "비공개");
+    Retro blindedRetro = Retro.of(publicMember.getId(), "라인", "iOS", LocalDate.now(), "1차",
+        "#Swift", "K", "P",
+        "T", "블라인드");
+    blindedRetro.report();
+    blindedRetro.report();
+
+    memberRepository.save(publicMember);
+    memberRepository.save(privateMember);
+    retroRepository.save(publicRetro);
+    retroRepository.save(privateRetro);
+    retroRepository.save(blindedRetro);
+    em.flush();
+    em.clear();
+
+    // when
+    var result = retroRepository.findPublicRetrosWithCursor(null, querySize);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().getCompanyName()).isEqualTo("네이버");
+    assertThat(result.getFirst().getPosition()).isEqualTo("BE");
+  }
 
   @Test
   @DisplayName("Cascade.ALL 검증: 회고를 저장하면 별도의 저장 호출 없이 면접 질문도 DB에 저장된다.")
@@ -108,7 +149,7 @@ class RetroRepositoryTest {
   // Member 생성 헬퍼 메서드
   private Member createAndSaveMember() {
     Term term = Term.from(true);
-    Member member = Member.of(Provider.KAKAO, "test-id", "닉네임", term);
+    Member member = Member.of(Provider.KAKAO, UUID.randomUUID().toString(), "닉네임", term);
     return memberRepository.save(member);
   }
 }


### PR DESCRIPTION
- 커뮤니티 피드 조회 API 기능 구현 
- 피드 조회 API의 응답에 사용되는 record 객체 정의
- 개발사항에 대한 서비스, 영속 계층 테스트 진행