### PR TITLE
[Feat] 닉네임 조회 API 및 관련 테스트 추가

### DIFF
--- a/src/main/java/com/retro/domain/member/application/MemberService.java
+++ b/src/main/java/com/retro/domain/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package com.retro.domain.member.application;
 
+import com.retro.domain.member.application.dto.MemberNicknameResponse;
 import com.retro.domain.member.domain.MemberRepository;
 import com.retro.domain.member.domain.entity.Member;
 import com.retro.domain.member.domain.event.MemberEventPublisher;
@@ -41,6 +42,11 @@ public class MemberService {
       return;
     }
     member.closeOwnPublication();
+  }
+
+  public MemberNicknameResponse getNickname(Long memberId) {
+    Member member = getMember(memberId);
+    return MemberNicknameResponse.from(member.getNickname());
   }
 
   @Transactional

--- a/src/main/java/com/retro/domain/member/application/dto/MemberNicknameResponse.java
+++ b/src/main/java/com/retro/domain/member/application/dto/MemberNicknameResponse.java
@@ -1,0 +1,10 @@
+package com.retro.domain.member.application.dto;
+
+public record MemberNicknameResponse(
+    String nickname
+) {
+
+  public static MemberNicknameResponse from(String nickname) {
+    return new MemberNicknameResponse(nickname);
+  }
+}

--- a/src/main/java/com/retro/domain/member/presentation/MemberController.java
+++ b/src/main/java/com/retro/domain/member/presentation/MemberController.java
@@ -2,6 +2,7 @@ package com.retro.domain.member.presentation;
 
 import com.retro.domain.member.application.MemberService;
 import com.retro.domain.member.application.dto.MemberMarketingAgreedUpdateRequest;
+import com.retro.domain.member.application.dto.MemberNicknameResponse;
 import com.retro.domain.member.application.dto.MemberNicknameUpdateRequest;
 import com.retro.domain.member.application.dto.MemberPublicUpdateRequest;
 import com.retro.domain.member.application.dto.MemberServiceTermAgreedUpdateRequest;
@@ -13,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,6 +46,23 @@ public class MemberController {
   ) {
     memberService.updatePostPublicStatus(securityUtil.getAuthenticatedUserId(), request.isPublic());
     return ApiResponse.success();
+  }
+
+  @Operation(
+      summary = "닉네임 조회",
+      description = "현재 인증된 회원의 닉네임을 조회합니다."
+  )
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "200",
+      description = "성공",
+      content = @io.swagger.v3.oas.annotations.media.Content(
+          mediaType = MediaType.APPLICATION_JSON_VALUE
+      )
+  )
+  @GetMapping("/nickname")
+  public ApiResponse<MemberNicknameResponse> getNickname() {
+    MemberNicknameResponse response = memberService.getNickname(securityUtil.getAuthenticatedUserId());
+    return ApiResponse.success(response);
   }
 
   @Operation(

--- a/src/test/java/com/retro/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/com/retro/domain/member/application/MemberServiceTest.java
@@ -1,17 +1,20 @@
 package com.retro.domain.member.application;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
+import com.retro.domain.member.application.dto.MemberNicknameResponse;
 import com.retro.domain.member.domain.MemberRepository;
 import com.retro.domain.member.domain.entity.Member;
 import com.retro.domain.member.domain.entity.Provider;
 import com.retro.domain.member.domain.entity.RetroReadPermission;
 import com.retro.domain.member.domain.entity.Term;
 import com.retro.domain.member.domain.event.MemberEventPublisher;
+import com.retro.global.common.exception.BusinessException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,6 +86,33 @@ class MemberServiceTest {
     // then
     assertThat(member.getIsPublic()).isFalse();
     assertThat(member.getRetroReadPermission()).isEqualTo(RetroReadPermission.LIMITED);
+  }
+
+  @Test
+  @DisplayName("성공: 닉네임 조회 시 현재 닉네임을 반환한다.")
+  void getNickname() {
+    // given
+    Long memberId = 1L;
+    Member member = Member.of(Provider.GOOGLE, "google-123", "테스트닉네임", Term.from(true));
+    given(memberRepository.findById(memberId)).willReturn(Optional.of(member));
+
+    // when
+    MemberNicknameResponse response = memberService.getNickname(memberId);
+
+    // then
+    assertThat(response.nickname()).isEqualTo("테스트닉네임");
+  }
+
+  @Test
+  @DisplayName("실패: 존재하지 않는 회원 닉네임 조회 시 BusinessException이 발생한다.")
+  void getNickname_throwException_whenMemberNotFound() {
+    // given
+    Long memberId = 99L;
+    given(memberRepository.findById(memberId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> memberService.getNickname(memberId))
+        .isInstanceOf(BusinessException.class);
   }
 
   @Test

--- a/src/test/java/com/retro/domain/member/presentation/MemberControllerTest.java
+++ b/src/test/java/com/retro/domain/member/presentation/MemberControllerTest.java
@@ -4,11 +4,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.retro.domain.member.application.MemberService;
+import com.retro.domain.member.application.dto.MemberNicknameResponse;
 import com.retro.domain.member.application.dto.MemberNicknameUpdateRequest;
 import com.retro.global.common.utils.SecurityUtil;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +43,32 @@ class MemberControllerTest {
 
   @MockitoBean
   private SecurityUtil securityUtil;
+
+  @Test
+  @WithMockUser
+  @DisplayName("통합 성공: 닉네임 조회 시 200 OK와 닉네임 반환")
+  void getNicknameSuccess() throws Exception {
+    // Given
+    Long memberId = 1L;
+    MemberNicknameResponse response = MemberNicknameResponse.from("회고러123");
+    given(securityUtil.getAuthenticatedUserId()).willReturn(memberId);
+    given(memberService.getNickname(memberId)).willReturn(response);
+
+    // When & Then
+    mockMvc.perform(get("/api/v1/members/nickname")
+            .contentType(APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.nickname").value("회고러123"));
+  }
+
+  @Test
+  @DisplayName("통합 실패: 미인증 사용자가 닉네임 조회 시 401 Unauthorized")
+  void getNicknameUnauthorized() throws Exception {
+    // When & Then
+    mockMvc.perform(get("/api/v1/members/nickname")
+            .contentType(APPLICATION_JSON))
+        .andExpect(status().isUnauthorized());
+  }
 
   @Test
   @WithMockUser


### PR DESCRIPTION
## Summary

- 마이페이지에서 현재 인증된 회원의 닉네임을 조회할 수 있는 API 추가
- 기존 닉네임 수정 API(`PATCH /api/v1/members/nickname`)와 함께 조회/수정 
- 서비스 단위 테스트 및 컨트롤러 통합 테스트 추가

Closes #41